### PR TITLE
Add patch store

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ditto",
-  "version": "0.101",
+  "version": "0.1.0",
   "scripts": {
     "dev": "vite dev --host 127.0.0.1 --port 3000",
     "build": "vite build",

--- a/src/components/views/Controls.svelte
+++ b/src/components/views/Controls.svelte
@@ -1,38 +1,23 @@
 <script lang="ts">
-  import type { Channels, Param } from '$lib/audio/index.js'
+  import { onDestroy } from 'svelte'
 
   import { limits, process } from '$lib/audio/delay.js'
+  import { presetStore } from '../../stores.js'
   import { translateToRange } from '$lib/utils.js'
+  import type { Channels, Preset } from '$lib/audio/index.js'
   import Knob from '$components/controls/Knob.svelte'
 
   export let input: Channels
   export let render: (channels: Channels) => void
 
-  const params: Record<string, Param> = {
-    delayTime: {
-      label: 'Time',
-      value: 200,
-      min: 0,
-      max: 1000,
-      unitLabel: 'ms'
-    },
-    feedback: {
-      label: 'Feedback',
-      value: 0,
-      min: 0,
-      max: 100,
-      unitLabel: '%'
-    },
-    mix: {
-      label: 'Mix',
-      value: 50,
-      min: 0,
-      max: 100,
-      unitLabel: '%'
-    }
-  }
-
+  let params: Preset
   let selectedParam: keyof typeof params | null = null
+
+  const unsubscribePresetStore = presetStore.subscribe(val => {
+    params = val
+  })
+
+  onDestroy(unsubscribePresetStore)
 
   function selectParam(event: CustomEvent<{ id: keyof typeof params }>) {
     const { id } = event.detail
@@ -66,6 +51,8 @@
         params.mix.value = value
         break
     }
+
+    presetStore.set(params)
   }
 
   $: {

--- a/src/components/views/Controls.svelte
+++ b/src/components/views/Controls.svelte
@@ -14,7 +14,6 @@
       value: 200,
       min: 0,
       max: 1000,
-      step: 1,
       unitLabel: 'ms'
     },
     feedback: {
@@ -22,7 +21,6 @@
       value: 0,
       min: 0,
       max: 100,
-      step: 1,
       unitLabel: '%'
     },
     mix: {
@@ -30,7 +28,6 @@
       value: 50,
       min: 0,
       max: 100,
-      step: 1,
       unitLabel: '%'
     }
   }

--- a/src/lib/audio/index.ts
+++ b/src/lib/audio/index.ts
@@ -8,13 +8,12 @@ export type Limits = {
 
 type Param = {
   label: string
-  value: number
   min: number
   max: number
   unitLabel: string
 }
 
-export type Preset = {
+export type Params = {
   delayTime: Param
   feedback: Param
   mix: Param

--- a/src/lib/audio/index.ts
+++ b/src/lib/audio/index.ts
@@ -11,7 +11,5 @@ export type Param = {
   value: number
   min: number
   max: number
-  step: number
   unitLabel: string
-  hidden?: boolean
 }

--- a/src/lib/audio/index.ts
+++ b/src/lib/audio/index.ts
@@ -6,10 +6,16 @@ export type Limits = {
   [key: string]: { min: number; max: number }
 }
 
-export type Param = {
+type Param = {
   label: string
   value: number
   min: number
   max: number
   unitLabel: string
+}
+
+export type Preset = {
+  delayTime: Param
+  feedback: Param
+  mix: Param
 }

--- a/src/lib/patch/index.ts
+++ b/src/lib/patch/index.ts
@@ -1,0 +1,11 @@
+import type { Params } from '$lib/audio'
+
+export type Patch = {
+  version: string
+  id: string
+  creator: string
+  params: { [Property in keyof Params]: number }
+  notes: string
+  tags: string[]
+  visibility: 'public' | 'private'
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,3 +5,12 @@ export const translateToRange = ({ num, original, scaled }: {
 }): number => {
   return ((scaled.max - scaled.min) * (num - original.min)) / (original.max - original.min) + scaled.min
 }
+
+// Object.entries with type inference
+export const objectEntries = <T extends object>(obj: T) => {
+  return Object.entries(obj) as Entries<T>
+}
+
+type Entries<T> = {
+  [K in keyof T]: [K, T[K]];
+}[keyof T][]

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -1,28 +1,19 @@
 import { writable } from 'svelte/store'
 import type { Writable } from 'svelte/store'
 
-import type { Preset } from '$lib/audio'
+import { version } from '../package.json'
+import type { Patch } from '$lib/patch'
 
-export const presetStore: Writable<Preset> = writable({
-  delayTime: {
-    label: 'Time',
-    value: 200,
-    min: 0,
-    max: 1000,
-    unitLabel: 'ms'
+export const patchStore: Writable<Patch> = writable({
+  version,
+  id: 'default',
+  creator: 'bgins',
+  params: {
+    delayTime: 200,
+    feedback: 0,
+    mix: 50
   },
-  feedback: {
-    label: 'Feedback',
-    value: 0,
-    min: 0,
-    max: 100,
-    unitLabel: '%'
-  },
-  mix: {
-    label: 'Mix',
-    value: 50,
-    min: 0,
-    max: 100,
-    unitLabel: '%'
-  }
+  notes: '',
+  tags: [],
+  visibility: 'public'
 })

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -1,0 +1,28 @@
+import { writable } from 'svelte/store'
+import type { Writable } from 'svelte/store'
+
+import type { Preset } from '$lib/audio'
+
+export const presetStore: Writable<Preset> = writable({
+  delayTime: {
+    label: 'Time',
+    value: 200,
+    min: 0,
+    max: 1000,
+    unitLabel: 'ms'
+  },
+  feedback: {
+    label: 'Feedback',
+    value: 0,
+    min: 0,
+    max: 100,
+    unitLabel: '%'
+  },
+  mix: {
+    label: 'Mix',
+    value: 50,
+    min: 0,
+    max: 100,
+    unitLabel: '%'
+  }
+})


### PR DESCRIPTION
# Description

This PR implements the following features:

- [x] Add patch store
- [x] Move param values to patch store
- [x] Add typed `Object.entries` utility

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactor (non-breaking change that updates existing functionality)