### PR TITLE
Filter out setParam events when selectedParam is null

### DIFF
--- a/src/components/views/Effect.svelte
+++ b/src/components/views/Effect.svelte
@@ -60,6 +60,8 @@
   function setParam(
     event: CustomEvent<{ id: keyof typeof params; value: number }>
   ) {
+    if (selectedParam === null) return
+
     const { id, value } = event.detail
 
     switch (id) {


### PR DESCRIPTION
# Description

This PR fixes the following issues:

- [x] `setParam` updates patch store when no param is selected

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test plan (required)

Add a console log to the body of `setParam` to check if the function early returns when `selectedParam` is `null`. This should occur when mousing over the Effect interface without a knob selected.

