### PR TITLE
Feat: add logo that goes to effects when clicked

### DIFF
--- a/src/components/Presets/PresetHeader.svelte
+++ b/src/components/Presets/PresetHeader.svelte
@@ -26,7 +26,7 @@
   })
 </script>
 
-<div class="relative flex gap-2 min-w-[450px] max-w-[300px] text-ellipsis overflow-hidden items-center justify-between translate-x-[70px] p-2 rounded-lg border-2 text-slate-900 hover:border-secondary/50 transition-colors ease-in-out bg-base-300 {borderColor}">
+<div class="relative flex gap-2 min-w-[450px] max-w-[300px] text-ellipsis overflow-hidden items-center justify-between translate-x-[56px] p-2 rounded-lg border-2 text-slate-900 hover:border-secondary/50 transition-colors ease-in-out bg-base-300 {borderColor}">
   <Notifications />
 
   <!-- {#if !isDefault} -->

--- a/src/components/Presets/PresetInfo.svelte
+++ b/src/components/Presets/PresetInfo.svelte
@@ -2,6 +2,7 @@
   import { fly } from 'svelte/transition'
 
   import type { Patch } from '$lib/patch'
+  import { DEFAULT_CATEGORIES } from '$lib/presets/constants'
   import { presetsStore } from '../../stores'
   import Delete from '$components/icons/Delete.svelte'
   import Edit from '$components/icons/Edit.svelte'
@@ -56,7 +57,13 @@
       <span class="text-sm font-semibold">Tags:</span>
       <div class="-translate-y-0.5">
         {#each preset.tags as tag}
-          <div on:click={() => handleCategoryClick(tag)} on:keydown={() => handleCategoryClick(tag)} class="badge badge-slate-900 pb-5 cursor-pointer text-base-100 ml-2 mb-1.5 inline-block hover:bg-secondary/70 hover:border-secondary/70 ease-in-out {$presetsStore.selectedCategory === tag ? 'bg-secondary/70 border-secondary/70' : ''}">{tag}</div>
+          <div on:click={() => {
+            if ($presetsStore.selectedCategory === tag) {
+              presetsStore.update((state) => ({ ...state, selectedCategory: DEFAULT_CATEGORIES[0] }))
+            } else {
+              handleCategoryClick(tag)
+            }
+          }} on:keydown={() => handleCategoryClick(tag)} class="badge badge-slate-900 pb-5 cursor-pointer text-base-100 ml-2 mb-1.5 inline-block hover:bg-secondary/70 hover:border-secondary/70 ease-in-out {$presetsStore.selectedCategory === tag ? 'bg-secondary/70 border-secondary/70' : ''}">{tag}</div>
         {/each}
       </div>
     </div>

--- a/src/components/icons/Logo.svelte
+++ b/src/components/icons/Logo.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte'
+
+  const dispatch = createEventDispatcher()
+
+  function handleClick() {
+    dispatch('click', { view: 'effect' })
+  }
+</script>
+
+<div on:click={handleClick} on:keydown={handleClick} class="flex items-center gap-2 cursor-pointer">
+  <svg xmlns="http://www.w3.org/2000/svg" width="28" height="29" fill="none"><rect width="26" height="26" x="1" y="1" stroke="#0F172A" stroke-width="2" rx="5"/><path fill="#0F172A" d="M19.228 9.49c-.18.76-.37 1.58-.57 2.46-.2.88-.38 1.74-.54 2.58-.16.84-.29 1.61-.39 2.31h-2.85l-.21-.33c.18-.7.41-1.45.69-2.25.28-.82.59-1.64.93-2.46.34-.82.67-1.59.99-2.31h1.95Zm-5.55 0c-.18.76-.37 1.58-.57 2.46-.2.88-.38 1.74-.54 2.58-.16.84-.29 1.61-.39 2.31h-2.82l-.18-.33c.18-.7.41-1.45.69-2.25.28-.82.58-1.64.9-2.46.34-.82.67-1.59.99-2.31h1.92Z"/></svg>
+  <h2 class="text-xl font-mono cursor-pointer">Ditto</h2>
+</div>

--- a/src/components/icons/Logo.svelte
+++ b/src/components/icons/Logo.svelte
@@ -8,7 +8,7 @@
   }
 </script>
 
-<div on:click={handleClick} on:keydown={handleClick} class="flex items-center gap-2 cursor-pointer">
-  <svg xmlns="http://www.w3.org/2000/svg" width="28" height="29" fill="none"><rect width="26" height="26" x="1" y="1" stroke="#0F172A" stroke-width="2" rx="5"/><path fill="#0F172A" d="M19.228 9.49c-.18.76-.37 1.58-.57 2.46-.2.88-.38 1.74-.54 2.58-.16.84-.29 1.61-.39 2.31h-2.85l-.21-.33c.18-.7.41-1.45.69-2.25.28-.82.59-1.64.93-2.46.34-.82.67-1.59.99-2.31h1.95Zm-5.55 0c-.18.76-.37 1.58-.57 2.46-.2.88-.38 1.74-.54 2.58-.16.84-.29 1.61-.39 2.31h-2.82l-.18-.33c.18-.7.41-1.45.69-2.25.28-.82.58-1.64.9-2.46.34-.82.67-1.59.99-2.31h1.92Z"/></svg>
+<div on:click={handleClick} on:keydown={handleClick} class="flex items-center gap-2 cursor-pointer hover:text-primary transition-colors ease-in-out">
+  <svg xmlns="http://www.w3.org/2000/svg" width="28" height="29" fill="none"><rect width="26" height="26" x="1" y="1" stroke="currentColor" stroke-width="2" rx="5"/><path fill="currentColor" d="M19.228 9.49c-.18.76-.37 1.58-.57 2.46-.2.88-.38 1.74-.54 2.58-.16.84-.29 1.61-.39 2.31h-2.85l-.21-.33c.18-.7.41-1.45.69-2.25.28-.82.59-1.64.93-2.46.34-.82.67-1.59.99-2.31h1.95Zm-5.55 0c-.18.76-.37 1.58-.57 2.46-.2.88-.38 1.74-.54 2.58-.16.84-.29 1.61-.39 2.31h-2.82l-.18-.33c.18-.7.41-1.45.69-2.25.28-.82.58-1.64.9-2.46.34-.82.67-1.59.99-2.31h1.92Z"/></svg>
   <h2 class="text-xl font-mono cursor-pointer">Ditto</h2>
 </div>

--- a/src/components/icons/UnsavedChanges.svelte
+++ b/src/components/icons/UnsavedChanges.svelte
@@ -26,5 +26,5 @@
 </script>
 
 {#if $patchStore.id !== 'default' && unsavedChanges}
-  <button in:fade on:click={handleSavePatch} class="absolute top-1/2 -translate-y-1/2 right-14 cursor-pointer flex items-center gap-2"><title>Save changes</title><Edit /></button>
+  <button in:fade on:click={handleSavePatch} class="animate-pulse absolute top-1/2 -translate-y-1/2 right-14 cursor-pointer flex items-center gap-2 text-primary"><title>Save changes</title><Edit /></button>
 {/if}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,6 +10,7 @@
   import Connect from '$components/views/Connect.svelte'
   import ConnectIcon from '$components/icons/Connect.svelte'
   import LoadingSpinner from '$components/common/LoadingSpinner.svelte'
+  import Logo from '$components/icons/Logo.svelte'
   import PresetHeader from '$components/presets/PresetHeader.svelte'
   import Presets from '$components/views/Presets.svelte'
   import PresetsIcon from '$components/icons/Presets.svelte'
@@ -56,9 +57,9 @@
       <LoadingSpinner />
     {:else}
       <div class="grid grid-flow-col auto-cols w-full items-center px-2 pl-5 py-5 backdrop-blur-sm bg-base-100 border-b">
-        <h2 class="text-2xl font-mono cursor-pointer">Ditto</h2>
+        <Logo on:click={setView} />
         <div class="relative max-w-[500px] flex items-center justify-center">
-          <div class="absolute left-[68px]">
+          <div class="absolute left-[54px]">
             {#if  view === 'presets'}
               <CloseIcon on:click={setView} />
             {:else if view === 'effect' || view === 'connect'}


### PR DESCRIPTION
# Description

- Adds simple logomark that goes to the effects route when clicked

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Test plan (required)

Click the logomark, expect it to go to the effects view

## Screenshots/Screencaps

<img width="1269" alt="image" src="https://user-images.githubusercontent.com/1179291/219908183-acde1b88-6113-4573-a095-9ce840a6cb1c.png">

