### PR TITLE
Avivash/animations and keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,14 @@ Build the project:
 ```bash
 npm run build
 ```
+
+## Keyboard Shortcuts
+
+- `esc` - Navigate to home screen
+- `n` - Create new preset
+- `e` - Edit selected preset
+- `c` - Navigate to connection screen
+- `l` - View presets list
+- `left/up` - Previous preset
+- `right/down` - Next preset
+- `shift` - View keyboard shortcuts menu

--- a/src/components/Presets/AddPreset.svelte
+++ b/src/components/Presets/AddPreset.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { fly } from 'svelte/transition'
+
   import { version } from '../../../package.json'
   import { patchStore, presetsStore } from '../../stores'
   import { addNotification } from '$lib/notifications'
@@ -58,7 +60,7 @@
   }
 </script>
 
-<form on:submit={handleSubmit}>
+<form on:submit={handleSubmit} in:fly={{ x: -20, duration: 400 }}>
   <h1 class="text-2xl font-bold mb-4">New Preset</h1>
 
   <label for="name" class="mb-1 text-xs">Name</label>

--- a/src/components/Presets/EditPreset.svelte
+++ b/src/components/Presets/EditPreset.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { fly } from 'svelte/transition'
+
   import { patchStore, presetsStore } from '../../stores'
   import { getUsername } from '$lib/auth'
   import { addNotification } from '$lib/notifications'
@@ -50,7 +52,7 @@
   }
 </script>
 
-<form on:submit={handleSubmit} class="relative">
+<form on:submit={handleSubmit} class="relative" in:fly={{ x: -20, duration: 400 }}>
   <h1 class="text-2xl font-bold mb-4">Edit Preset</h1>
 
   <label for="name" class="mb-1 text-xs">Name</label>

--- a/src/components/Presets/PresetHeader.svelte
+++ b/src/components/Presets/PresetHeader.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
-
-  import { notificationStore, patchStore } from '../../stores'
+  import { notificationStore, patchStore, viewStore } from '../../stores'
   import ArrowLeft from '$components/icons/ArrowLeft.svelte'
   import ArrowRight from '$components/icons/ArrowRight.svelte'
   import Favorite from '$components/icons/Favorite.svelte'
@@ -9,10 +7,8 @@
 
   $: isDefault = $patchStore.id === 'default'
 
-  const dispatch = createEventDispatcher()
-
   const handleClick = () => {
-    dispatch('click', { view: 'presets' })
+    viewStore.update((state) => ({ ...state, globalView: 'presets', presetsView: 'view' }))
   }
 
   // Change border colours based on notification type

--- a/src/components/Presets/PresetInfo.svelte
+++ b/src/components/Presets/PresetInfo.svelte
@@ -3,14 +3,19 @@
 
   import type { Patch } from '$lib/patch'
   import { DEFAULT_CATEGORIES } from '$lib/presets/constants'
-  import { presetsStore } from '../../stores'
+  import { presetsStore, viewStore } from '../../stores'
   import Delete from '$components/icons/Delete.svelte'
   import Edit from '$components/icons/Edit.svelte'
   import Favorite from '$components/icons/Favorite.svelte'
 
   export let preset: Patch
-  export let handleEditClick: () => void
   export let handleCategoryClick: (category: string) => void
+
+  const handleEditClick = () => viewStore.update((state) => ({
+    ...state,
+    presetsView: 'edit',
+  }))
+
 
   $: isDefault = preset?.id === 'default'
 </script>

--- a/src/components/common/GlobalShortcutHandler.svelte
+++ b/src/components/common/GlobalShortcutHandler.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  import { patchStore, viewStore } from '../../stores'
+  import { addNotification } from '$lib/notifications'
+  import { DEFAULT_PATCH } from '$lib/patch'
+
+  type KeyMap = {
+    [key: string]: () => void
+  }
+
+  // Map keys to actions
+  const keyMap: KeyMap = {
+    c: () => viewStore.update((state) => ({
+      ...state,
+      globalView: 'connect',
+    })),
+    Escape: () => viewStore.update((state) => ({
+      ...state,
+      globalView: 'effect',
+      presetsView: 'view',
+    })),
+    e: () => {
+      if ($patchStore.id === DEFAULT_PATCH.id) {
+        addNotification('Cannot edit default patch', 'warning')
+        return
+      }
+
+      viewStore.update((state) => ({
+        ...state,
+        globalView: 'presets',
+        presetsView: 'edit',
+      }))
+    },
+    n: () => viewStore.update((state) => ({
+      ...state,
+      globalView: 'presets',
+      presetsView: 'add',
+    })),
+    p: () => viewStore.update((state) => ({
+      ...state,
+      globalView: 'presets',
+      presetsView: 'view',
+    })),
+    Shift: () => viewStore.update((state) => ({
+      ...state,
+      showShortcuts: true,
+    })),
+  }
+
+  // Only register key strokes from the keyMap
+  const allowedKeys = Object.keys(keyMap)
+
+  // Enable global keyboard shortcuts if the user has not focused on a form element
+  const handleKeyDown = (event: KeyboardEvent): void => {
+    const tagName = (event?.target as HTMLElement).tagName.toLowerCase()
+    const key = event.key
+
+    if (!['input', 'select', 'textarea'].includes(tagName) && allowedKeys.includes(key)) {
+      keyMap[key]()
+    }
+  }
+
+  const handleKeyUp = (event: KeyboardEvent): void => {
+    const tagName = (event?.target as HTMLElement).tagName.toLowerCase()
+    const key = event.key
+
+    if (!['input', 'select', 'textarea'].includes(tagName) && key === 'Shift') {
+      viewStore.update((state) => ({
+        ...state,
+        showShortcuts: false,
+      }))
+    }
+  }
+</script>
+
+<svelte:window on:keydown={handleKeyDown} on:keyup={handleKeyUp} />

--- a/src/components/common/GlobalShortcutHandler.svelte
+++ b/src/components/common/GlobalShortcutHandler.svelte
@@ -49,12 +49,15 @@
   // Only register key strokes from the keyMap
   const allowedKeys = Object.keys(keyMap)
 
+  // Shortcuts are disabled if these elements are focused on
+  const formElements = ['input', 'select', 'textarea']
+
   // Enable global keyboard shortcuts if the user has not focused on a form element
   const handleKeyDown = (event: KeyboardEvent): void => {
     const tagName = (event?.target as HTMLElement).tagName.toLowerCase()
     const key = event.key
 
-    if (!['input', 'select', 'textarea'].includes(tagName) && allowedKeys.includes(key)) {
+    if (!formElements.includes(tagName) && allowedKeys.includes(key)) {
       keyMap[key]()
     }
   }
@@ -63,7 +66,7 @@
     const tagName = (event?.target as HTMLElement).tagName.toLowerCase()
     const key = event.key
 
-    if (!['input', 'select', 'textarea'].includes(tagName) && key === 'Shift') {
+    if (!formElements.includes(tagName) && key === 'Shift') {
       viewStore.update((state) => ({
         ...state,
         showShortcuts: false,

--- a/src/components/common/GlobalShortcutHandler.svelte
+++ b/src/components/common/GlobalShortcutHandler.svelte
@@ -35,7 +35,7 @@
       globalView: 'presets',
       presetsView: 'add',
     })),
-    p: () => viewStore.update((state) => ({
+    l: () => viewStore.update((state) => ({
       ...state,
       globalView: 'presets',
       presetsView: 'view',

--- a/src/components/common/GlobalShortcutView.svelte
+++ b/src/components/common/GlobalShortcutView.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  type ShortcupMap = {
+    [key: string]: string
+  }
+
+  const shortcutMap: ShortcupMap = {
+    esc: 'Navigate to home screen',
+    n: 'Create new preset',
+    e: 'Edit selected preset',
+    c: 'Navigate to connection screen',
+    p: 'Navigate to presets screen',
+    'left/up': 'Previous preset',
+    'right/down': 'Next preset',
+    shift: 'View keyboard shortcuts menu',
+  }
+</script>
+
+<div class="flex flex-col justify-center gap-4 absolute z-10 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-lg bg-slate-900/70 p-20">
+  {#each Object.keys(shortcutMap) as key}
+    <div class="flex gap-4 items-center justify-start">
+      <kbd class="px-2 py-1.5 text-xs font-semibold text-slate-900 bg-gray-100 border border-gray-200 rounded-lg">{key}</kbd><span class="flex gap-4 text-gray-100 font-mono">-
+      <p class="justify-self-end">{shortcutMap[key]}</p></span>
+    </div>
+  {/each}
+</div>

--- a/src/components/common/GlobalShortcutView.svelte
+++ b/src/components/common/GlobalShortcutView.svelte
@@ -8,14 +8,14 @@
     n: 'Create new preset',
     e: 'Edit selected preset',
     c: 'Navigate to connection screen',
-    p: 'Navigate to presets screen',
+    l: 'View presets list',
     'left/up': 'Previous preset',
     'right/down': 'Next preset',
     shift: 'View keyboard shortcuts menu',
   }
 </script>
 
-<div class="flex flex-col justify-center gap-4 absolute z-10 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-lg bg-slate-900/70 p-20">
+<div class="flex flex-col justify-center gap-4 absolute z-10 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-lg bg-slate-900/80 p-20">
   {#each Object.keys(shortcutMap) as key}
     <div class="flex gap-4 items-center justify-start">
       <kbd class="px-2 py-1.5 text-xs font-semibold text-slate-900 bg-gray-100 border border-gray-200 rounded-lg">{key}</kbd><span class="flex gap-4 text-gray-100 font-mono">-

--- a/src/components/icons/ArrowLeft.svelte
+++ b/src/components/icons/ArrowLeft.svelte
@@ -9,7 +9,7 @@
     presetsStore.update((state) => ({ ...state, selectedPatch: $presetsStore.presets[prevIndex].id }))
   }
 
-// Enable keyboard navigation if the user has not focused on a form element
+  // Enable keyboard navigation if the user has not focused on a form element
   const handleKeyDown = (event: KeyboardEvent) => {
     const tagName = (event?.target as HTMLElement).tagName.toLowerCase()
     const key = event.key

--- a/src/components/icons/Close.svelte
+++ b/src/components/icons/Close.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
+  import { viewStore } from '../../stores'
 
   let strokeWidth = 1.5
 
-  const dispatch = createEventDispatcher()
-
   function handleClick() {
-    dispatch('click', { view: 'effect' })
+    viewStore.update((state) => ({ ...state, globalView: 'effect', presetsView: 'view' }))
   }
 </script>
 

--- a/src/components/icons/Connect.svelte
+++ b/src/components/icons/Connect.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
+  import { viewStore } from '../../stores'
 
   let strokeWidth = 1.5
 
-  const dispatch = createEventDispatcher()
-
   function handleClick() {
-    dispatch('click', { view: 'connect' })
+    viewStore.update((state) => ({ ...state, globalView: 'connect' }))
   }
 </script>
 

--- a/src/components/icons/Logo.svelte
+++ b/src/components/icons/Logo.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
-
-  const dispatch = createEventDispatcher()
+  import { viewStore } from '../../stores'
 
   function handleClick() {
-    dispatch('click', { view: 'effect' })
+    viewStore.update((state) => ({ ...state, globalView: 'effect', presetsView: 'view' }))
   }
 </script>
 

--- a/src/components/icons/Presets.svelte
+++ b/src/components/icons/Presets.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte'
+  import { viewStore } from '../../stores'
 
   let strokeWidth = 1.5
 
-  const dispatch = createEventDispatcher()
-
   function handleClick() {
-    dispatch('click', { view: 'presets' })
+    viewStore.update((state) => ({ ...state, globalView: 'presets', presetsView: 'view' }))
   }
 </script>
 

--- a/src/components/views/Connect.svelte
+++ b/src/components/views/Connect.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import type * as webnative from 'webnative'
-  import { createEventDispatcher, onDestroy } from 'svelte'
+  import { onDestroy } from 'svelte'
   import type { AccountLinkingProducer } from 'webnative'
 
-  import { authStore } from '../../stores'
+  import { authStore, viewStore } from '../../stores'
   import { setConnectedStatus } from '$lib/auth/connected'
   import Register from '$components/views/connect/Register.svelte'
   import Link from '$components/views/connect/Link.svelte'
@@ -11,8 +11,6 @@
   import Connected from '$components/views/connect/Connected.svelte'
 
   type View = 'register' | 'link' | 'confirm-pin' | 'connected'
-
-  const dispatch = createEventDispatcher()
 
   let authStrategy: webnative.AuthenticationStrategy | null
   let session: webnative.Session | null
@@ -60,7 +58,10 @@
   function handleLinkingCanceled() {
     if (accountLinkingProducer) accountLinkingProducer.cancel()
 
-    dispatch('navigate', { view: 'effect' })
+    viewStore.update((state) => ({
+      ...state,
+      globalView: 'effect',
+    }))
   }
 
   async function handleRelink() {

--- a/src/lib/views/index.ts
+++ b/src/lib/views/index.ts
@@ -1,0 +1,9 @@
+type GlobalView = 'connect' | 'effect' | 'presets'
+type PresetsView = 'add' | 'edit' | 'view'
+
+export type Views = {
+  globalView: GlobalView
+  presetsView: PresetsView
+  showShortcuts: boolean
+}
+

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,13 +2,15 @@
   import { el } from '@elemaudio/core'
   import { default as core } from '@elemaudio/plugin-renderer'
 
-  import { sessionStore } from '../stores'
+  import { sessionStore, viewStore } from '../stores'
   import { initialize } from '$lib/init'
   import type { Channels } from '$lib/audio/index'
   import Effect from '$components/views/Effect.svelte'
   import CloseIcon from '$components/icons/Close.svelte'
   import Connect from '$components/views/Connect.svelte'
   import ConnectIcon from '$components/icons/Connect.svelte'
+  import GlobalShortcutHandler from '$components/common/GlobalShortcutHandler.svelte'
+  import GlobalShortcutView from '$components/common/GlobalShortcutView.svelte'
   import LoadingSpinner from '$components/common/LoadingSpinner.svelte'
   import Logo from '$components/icons/Logo.svelte'
   import PresetHeader from '$components/presets/PresetHeader.svelte'
@@ -17,10 +19,7 @@
   // import Sync from '$components/icons/Sync.svelte'
   import UnsavedChanges from '$components/icons/UnsavedChanges.svelte'
 
-  type View = 'connect' | 'effect' | 'presets'
-
   let input: Channels
-  let view: View = 'effect'
   let loading = false
 
   // Initialize Elementary Audio
@@ -45,11 +44,9 @@
   }
 
   init().catch(console.log)
-
-  function setView(event: CustomEvent<{ view: View }>) {
-    view = event.detail.view
-  }
 </script>
+
+<GlobalShortcutHandler />
 
 {#if input}
   <div class="relative grid grid-flow-row auto-rows-max min-h-screen">
@@ -57,35 +54,39 @@
       <LoadingSpinner />
     {:else}
       <div class="grid grid-flow-col auto-cols w-full items-center px-2 pl-5 py-5 backdrop-blur-sm bg-base-100 border-b">
-        <Logo on:click={setView} />
+        <Logo />
         <div class="relative max-w-[500px] flex items-center justify-center">
           <div class="absolute left-[54px]">
-            {#if  view === 'presets'}
-              <CloseIcon on:click={setView} />
-            {:else if view === 'effect' || view === 'connect'}
-              <PresetsIcon on:click={setView} />
+            {#if $viewStore.globalView === 'presets'}
+              <CloseIcon />
+            {:else if $viewStore.globalView === 'effect' || $viewStore.globalView === 'connect'}
+              <PresetsIcon />
             {/if}
           </div>
-          <PresetHeader on:click={setView} />
+          <PresetHeader />
         </div>
         <div class="relative flex items-center justify-end pr-5 gap-5">
           <!-- {#if $sessionStore.connectedStatus}
             <Sync />
           {/if} -->
           <UnsavedChanges />
-          {#if view === 'connect'}
-            <CloseIcon on:click={setView} />
+          {#if $viewStore.globalView === 'connect'}
+            <CloseIcon />
           {:else}
-            <ConnectIcon on:click={setView} />
+            <ConnectIcon />
           {/if}
         </div>
       </div>
-      <div class="relative pl-4">
-        {#if view === 'effect'}
+      <div class="relative pl-4 h-full-no-header">
+        {#if $viewStore.showShortcuts}
+          <GlobalShortcutView />
+        {/if}
+
+        {#if $viewStore.globalView === 'effect'}
           <Effect {input} {render} />
-        {:else if view === 'connect'}
-          <Connect on:navigate={setView} />
-        {:else if view === 'presets'}
+        {:else if $viewStore.globalView === 'connect'}
+          <Connect />
+        {:else if $viewStore.globalView === 'presets'}
           <Presets />
         {/if}
       </div>

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -6,6 +6,7 @@ import { DEFAULT_PATCH, type Patch } from '$lib/patch'
 import { DEFAULT_CATEGORIES } from '$lib/presets/constants'
 import type { Session } from '$lib/auth/session'
 import type { Presets } from '$lib/presets'
+import type { Views } from '$lib/views'
 
 export const fileSystemStore: Writable<webnative.FileSystem | null> = writable(null)
 
@@ -40,3 +41,9 @@ export const authStore: Readable<{
       session: $session.session
     }
   })
+
+export const viewStore: Writable<Views> = writable({
+  globalView: 'effect',
+  presetsView: 'view',
+  showShortcuts: false
+})


### PR DESCRIPTION
# Description

- Adding animations to the edit/add forms to slide in from the opposite side as the default view
- Adding keyboard shortcuts for the keys listed here: 
<img width="509" alt="image" src="https://user-images.githubusercontent.com/1179291/223209046-0084a6a8-350d-4386-9e78-0a8b560ed1e8.png">

**ToDo in a follow-up PR: add granular control when holding cmd and turning a knob**

**Note: I was planning on using `/` as the shortcut menu key, but for some reason `keyup` events were only firing consistently for system keys(Meta, Ctrl, Shift, etc...)**

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Screenshots/Screencaps

**Keyboard shortcuts**
https://www.loom.com/share/2f4ef1594887488683950218dcc5dbc4

**Add/Edit animations**
https://www.loom.com/share/61600ba72e8d491c8d6eb7a2976d7388
